### PR TITLE
build: gradle to 8.6

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request includes a small change to update the Gradle distribution version in the `gradle-wrapper.properties` file. The change updates the distribution URL to use Gradle 8.6 instead of Gradle 8.1.1.

* [`gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3): Updated the `distributionUrl` to use Gradle 8.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Gradle version from 8.1.1 to 8.6 for improved performance and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->